### PR TITLE
Support connectionString in Test.R

### DIFF
--- a/extras/Test.R
+++ b/extras/Test.R
@@ -78,6 +78,7 @@ if (length(databases) > 0) {
                                                  server = databaseParameters$server,
                                                  port = databaseParameters$port,
                                                  extraSettings = databaseParameters$extraSettings,
+                                                 connectionString = databaseParameters$connectionString,
                                                  pathToDriver = Sys.getenv("DATABASECONNECTOR_JAR"))
 
     schemaDefinition <- list(cdm = databaseParameters$cdm, vocab = databaseParameters$vocab)


### PR DESCRIPTION
Minor extension to Test.R enabling the use of a custom JDBC URL in case server/port combinations aren't specific enough for the target database platform