### PR TITLE
Example DQ Queries

### DIFF
--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CDM_SOURCE.CDM_RELEASE_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CDM_SOURCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CDM_RELEASE_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CDM_SOURCE cdmTable
+		
+  	WHERE CDM_RELEASE_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_CDM_RELEASE_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CDM_SOURCE_CDM_RELEASE_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CDM_SOURCE.SOURCE_RELEASE_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CDM_SOURCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.SOURCE_RELEASE_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CDM_SOURCE cdmTable
+		
+  	WHERE SOURCE_RELEASE_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CDM_SOURCE_SOURCE_RELEASE_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CDM_SOURCE_SOURCE_RELEASE_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# COHORT_COHORT_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;COHORT.COHORT_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @resultsDatabaseSchema.COHORT cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.COHORT_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @resultsDatabaseSchema.COHORT cdmTable
+		
+  	WHERE COHORT_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# COHORT_COHORT_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/COHORT_COHORT_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;COHORT.COHORT_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @resultsDatabaseSchema.COHORT cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.COHORT_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @resultsDatabaseSchema.COHORT cdmTable
+		
+  	WHERE COHORT_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_ERA.CONDITION_ERA_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_ERA_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_ERA cdmTable
+		
+  	WHERE CONDITION_ERA_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_ERA_CONDITION_ERA_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_ERA.CONDITION_ERA_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_ERA_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_ERA cdmTable
+		
+  	WHERE CONDITION_ERA_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_ERA_CONDITION_ERA_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_ERA_CONDITION_ERA_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_OCCURRENCE_CONDITION_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_OCCURRENCE.CONDITION_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+		
+  	WHERE CONDITION_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_OCCURRENCE.CONDITION_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+		
+  	WHERE CONDITION_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_OCCURRENCE_CONDITION_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_OCCURRENCE.CONDITION_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+		
+  	WHERE CONDITION_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_OCCURRENCE_CONDITION_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# CONDITION_OCCURRENCE_CONDITION_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/CONDITION_OCCURRENCE_CONDITION_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;CONDITION_OCCURRENCE.CONDITION_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.CONDITION_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.CONDITION_OCCURRENCE cdmTable
+		
+  	WHERE CONDITION_START_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEATH_DEATH_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEATH.DEATH_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEATH cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEATH_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEATH cdmTable
+		
+  	WHERE DEATH_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEATH.DEATH_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEATH cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEATH_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEATH cdmTable
+		
+  	WHERE DEATH_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEATH_DEATH_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEATH_DEATH_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEVICE_EXPOSURE.DEVICE_EXPOSURE_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEVICE_EXPOSURE_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+		
+  	WHERE DEVICE_EXPOSURE_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEVICE_EXPOSURE.DEVICE_EXPOSURE_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEVICE_EXPOSURE_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+		
+  	WHERE DEVICE_EXPOSURE_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEVICE_EXPOSURE.DEVICE_EXPOSURE_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEVICE_EXPOSURE_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+		
+  	WHERE DEVICE_EXPOSURE_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DEVICE_EXPOSURE.DEVICE_EXPOSURE_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DEVICE_EXPOSURE_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DEVICE_EXPOSURE cdmTable
+		
+  	WHERE DEVICE_EXPOSURE_START_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DEVICE_EXPOSURE_DEVICE_EXPOSURE_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DOSE_ERA.DOSE_ERA_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DOSE_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DOSE_ERA_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DOSE_ERA cdmTable
+		
+  	WHERE DOSE_ERA_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DOSE_ERA_DOSE_ERA_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DOSE_ERA_DOSE_ERA_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DOSE_ERA_DOSE_ERA_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DOSE_ERA.DOSE_ERA_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DOSE_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DOSE_ERA_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DOSE_ERA cdmTable
+		
+  	WHERE DOSE_ERA_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_ERA_DRUG_ERA_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_ERA.DRUG_ERA_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_ERA_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_ERA cdmTable
+		
+  	WHERE DRUG_ERA_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_ERA_DRUG_ERA_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_ERA_DRUG_ERA_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_ERA.DRUG_ERA_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_ERA cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_ERA_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_ERA cdmTable
+		
+  	WHERE DRUG_ERA_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.DAYS_SUPPLY&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      		WHERE cdmTable.DAYS_SUPPLY &gt; 365
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE DAYS_SUPPLY IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DAYS_SUPPLY.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_DAYS_SUPPLY
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.DRUG_EXPOSURE_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_EXPOSURE_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE DRUG_EXPOSURE_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.DRUG_EXPOSURE_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_EXPOSURE_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE DRUG_EXPOSURE_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.DRUG_EXPOSURE_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_EXPOSURE_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE DRUG_EXPOSURE_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_DRUG_EXPOSURE_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.DRUG_EXPOSURE_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.DRUG_EXPOSURE_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE DRUG_EXPOSURE_START_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_QUANTITY
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_QUANTITY.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.QUANTITY&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      		WHERE cdmTable.QUANTITY &gt; 1095
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE QUANTITY IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.REFILLS&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      		WHERE cdmTable.REFILLS &gt; 12
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE REFILLS IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_REFILLS.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_REFILLS
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;DRUG_EXPOSURE.VERBATIM_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VERBATIM_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.DRUG_EXPOSURE cdmTable
+		
+  	WHERE VERBATIM_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/DRUG_EXPOSURE_VERBATIM_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# DRUG_EXPOSURE_VERBATIM_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;EPISODE.EPISODE_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.EPISODE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.EPISODE_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.EPISODE cdmTable
+		
+  	WHERE EPISODE_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# EPISODE_EPISODE_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# EPISODE_EPISODE_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;EPISODE.EPISODE_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.EPISODE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.EPISODE_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.EPISODE cdmTable
+		
+  	WHERE EPISODE_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# EPISODE_EPISODE_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;EPISODE.EPISODE_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.EPISODE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.EPISODE_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.EPISODE cdmTable
+		
+  	WHERE EPISODE_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# EPISODE_EPISODE_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/EPISODE_EPISODE_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;EPISODE.EPISODE_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.EPISODE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.EPISODE_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.EPISODE cdmTable
+		
+  	WHERE EPISODE_START_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;MEASUREMENT.MEASUREMENT_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.MEASUREMENT cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.MEASUREMENT_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.MEASUREMENT cdmTable
+		
+  	WHERE MEASUREMENT_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# MEASUREMENT_MEASUREMENT_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;MEASUREMENT.MEASUREMENT_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.MEASUREMENT cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.MEASUREMENT_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.MEASUREMENT cdmTable
+		
+  	WHERE MEASUREMENT_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/MEASUREMENT_MEASUREMENT_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# MEASUREMENT_MEASUREMENT_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# NOTE_NLP_NLP_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NLP_NLP_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;NOTE_NLP.NLP_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.NOTE_NLP cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.NLP_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.NOTE_NLP cdmTable
+		
+  	WHERE NLP_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# NOTE_NOTE_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;NOTE.NOTE_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.NOTE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.NOTE_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.NOTE cdmTable
+		
+  	WHERE NOTE_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;NOTE.NOTE_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.NOTE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.NOTE_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.NOTE cdmTable
+		
+  	WHERE NOTE_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/NOTE_NOTE_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# NOTE_NOTE_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# OBSERVATION_OBSERVATION_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;OBSERVATION.OBSERVATION_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.OBSERVATION cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.OBSERVATION_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.OBSERVATION cdmTable
+		
+  	WHERE OBSERVATION_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# OBSERVATION_OBSERVATION_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_OBSERVATION_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;OBSERVATION.OBSERVATION_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.OBSERVATION cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.OBSERVATION_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.OBSERVATION cdmTable
+		
+  	WHERE OBSERVATION_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;OBSERVATION_PERIOD.OBSERVATION_PERIOD_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.OBSERVATION_PERIOD cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.OBSERVATION_PERIOD_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.OBSERVATION_PERIOD cdmTable
+		
+  	WHERE OBSERVATION_PERIOD_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;OBSERVATION_PERIOD.OBSERVATION_PERIOD_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.OBSERVATION_PERIOD cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.OBSERVATION_PERIOD_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.OBSERVATION_PERIOD cdmTable
+		
+  	WHERE OBSERVATION_PERIOD_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# OBSERVATION_PERIOD_OBSERVATION_PERIOD_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PAYER_PLAN_PERIOD.PAYER_PLAN_PERIOD_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PAYER_PLAN_PERIOD cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PAYER_PLAN_PERIOD_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PAYER_PLAN_PERIOD cdmTable
+		
+  	WHERE PAYER_PLAN_PERIOD_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PAYER_PLAN_PERIOD.PAYER_PLAN_PERIOD_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PAYER_PLAN_PERIOD cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PAYER_PLAN_PERIOD_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PAYER_PLAN_PERIOD cdmTable
+		
+  	WHERE PAYER_PLAN_PERIOD_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PAYER_PLAN_PERIOD_PAYER_PLAN_PERIOD_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PERSON.BIRTH_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PERSON cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.BIRTH_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PERSON cdmTable
+		
+  	WHERE BIRTH_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_BIRTH_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PERSON_BIRTH_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PERSON_DAY_OF_BIRTH
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_DAY_OF_BIRTH.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PERSON.DAY_OF_BIRTH&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PERSON cdmTable
+    		
+    		
+      		WHERE cdmTable.DAY_OF_BIRTH &gt; 31
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PERSON cdmTable
+		
+  	WHERE DAY_OF_BIRTH IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PERSON_MONTH_OF_BIRTH
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_MONTH_OF_BIRTH.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PERSON.MONTH_OF_BIRTH&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PERSON cdmTable
+    		
+    		
+      		WHERE cdmTable.MONTH_OF_BIRTH &gt; 12
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PERSON cdmTable
+		
+  	WHERE MONTH_OF_BIRTH IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PERSON_YEAR_OF_BIRTH
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PERSON_YEAR_OF_BIRTH.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PERSON.YEAR_OF_BIRTH&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PERSON cdmTable
+    		
+    		
+      		WHERE cdmTable.YEAR_OF_BIRTH &gt; YEAR(GETDATE())&#43;1
+		
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PERSON cdmTable
+		
+  	WHERE YEAR_OF_BIRTH IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PROCEDURE_OCCURRENCE.PROCEDURE_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PROCEDURE_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+		
+  	WHERE PROCEDURE_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PROCEDURE_OCCURRENCE_PROCEDURE_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PROCEDURE_OCCURRENCE.PROCEDURE_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PROCEDURE_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+		
+  	WHERE PROCEDURE_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PROCEDURE_OCCURRENCE.PROCEDURE_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PROCEDURE_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+		
+  	WHERE PROCEDURE_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PROCEDURE_OCCURRENCE_PROCEDURE_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;PROCEDURE_OCCURRENCE.PROCEDURE_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.PROCEDURE_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.PROCEDURE_OCCURRENCE cdmTable
+		
+  	WHERE PROCEDURE_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# PROCEDURE_OCCURRENCE_PROCEDURE_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# SPECIMEN_SPECIMEN_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;SPECIMEN.SPECIMEN_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.SPECIMEN cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.SPECIMEN_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.SPECIMEN cdmTable
+		
+  	WHERE SPECIMEN_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;SPECIMEN.SPECIMEN_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.SPECIMEN cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.SPECIMEN_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.SPECIMEN cdmTable
+		
+  	WHERE SPECIMEN_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/SPECIMEN_SPECIMEN_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# SPECIMEN_SPECIMEN_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_DETAIL.VISIT_DETAIL_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_DETAIL_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+		
+  	WHERE VISIT_DETAIL_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_DETAIL_VISIT_DETAIL_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_DETAIL.VISIT_DETAIL_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_DETAIL_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+		
+  	WHERE VISIT_DETAIL_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_DETAIL_VISIT_DETAIL_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_DETAIL.VISIT_DETAIL_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_DETAIL_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+		
+  	WHERE VISIT_DETAIL_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_DETAIL_VISIT_DETAIL_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_DETAIL_VISIT_DETAIL_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_DETAIL_VISIT_DETAIL_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_DETAIL.VISIT_DETAIL_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_DETAIL_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_DETAIL cdmTable
+		
+  	WHERE VISIT_DETAIL_START_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_OCCURRENCE.VISIT_END_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_END_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+		
+  	WHERE VISIT_END_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_OCCURRENCE_VISIT_END_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_OCCURRENCE_VISIT_END_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_END_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_OCCURRENCE.VISIT_END_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_END_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+		
+  	WHERE VISIT_END_DATETIME IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_OCCURRENCE.VISIT_START_DATE&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_START_DATE as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+		
+  	WHERE VISIT_START_DATE IS NOT NULL
+) denominator
 ```
 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATE.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_OCCURRENCE_VISIT_START_DATE
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
@@ -12,7 +12,7 @@ get number of records and the proportion to total number of eligible records tha
 
 
 
-## Example
+## Query
 ```sql
 SELECT 
 	num_violated_rows, 

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
@@ -1,0 +1,25 @@
+
+
+
+
+# VISIT_OCCURRENCE_VISIT_START_DATETIME
+
+
+
+## Description
+PLAUSIBLE_VALUE_HIGH
+get number of records and the proportion to total number of eligible records that exceed this threshold
+
+
+
+## Example
+```sql
+SELECT 
+	num_violated_rows, 
+	CASE 
+		WHEN denominator.num_rows = 0 THEN 0 
+		ELSE 1.0*num_violated_rows/denominator.num_rows 
+	END AS pct_violated_rows, 
+  	denominator.num_rows AS num_denominator_rows
+```
+

--- a/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
+++ b/inst/shinyApps/QueryLibrary/queries/FIELD_plausibleValueHigh/VISIT_OCCURRENCE_VISIT_START_DATETIME.md
@@ -20,6 +20,29 @@ SELECT
 		WHEN denominator.num_rows = 0 THEN 0 
 		ELSE 1.0*num_violated_rows/denominator.num_rows 
 	END AS pct_violated_rows, 
-  	denominator.num_rows AS num_denominator_rows
+  	denominator.num_rows AS num_denominator_rowsFROM
+(
+	SELECT 
+		COUNT_BIG(violated_rows.violating_field) AS num_violated_rows
+	FROM
+	(
+		/*violatedRowsBegin*/
+		SELECT &#39;VISIT_OCCURRENCE.VISIT_START_DATETIME&#39; AS violating_field, 
+		cdmTable.*
+    	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+    		
+    		
+      	WHERE cast(cdmTable.VISIT_START_DATETIME as date) &gt; cast(DATEADD(dd,1,GETDATE()) as date)
+    	
+		/*violatedRowsEnd*/
+	) violated_rows
+) violated_row_count,
+(
+	SELECT 
+		COUNT_BIG(*) AS num_rows
+	FROM @cdmDatabaseSchema.VISIT_OCCURRENCE cdmTable
+		
+  	WHERE VISIT_START_DATETIME IS NOT NULL
+) denominator
 ```
 


### PR DESCRIPTION
Here is a naive example of DQ queries pulled from the DQD as discussed in #28 @fdefalco 

It seems like this could be reasonably done on an output file by file base - there appears to be one template per file. Some may require more massaging than others to make the template engine output useful here. I don't mind doing the parsing, but the main question is whether the templates used for these files are stable enough that I could reasonably use this as an API.

